### PR TITLE
add support for building R14 on Mountain Lion and newer

### DIFF
--- a/erlbrew
+++ b/erlbrew
@@ -103,23 +103,32 @@ build() {
   $UNTAR_CMD $UNTAR_FLAGS $DOWNLOAD_FILE 1>>"$TMP_PATH/erlbrew.log" 2>&1
   cd "$FILENAME"
 
-  OS_TYPE=$(uname -s)
+  echo "Configuring Erlang $RELEASE for $OSTYPE"
+  CFLAGS=""
 
-  echo "Configuring Erlang $RELEASE for $OS_TYPE"
-  case "$OS_TYPE" in
-    Darwin)
-      CFLAGS=-O0 ./configure --disable-hipe --without-javac --enable-smp-support \
-                         --enable-threads --enable-kernel-poll \
-                         --enable-darwin-64bit --prefix="$INSTALL" 1>>"$TMP_PATH/erlbrew.log" 2>&1
-      ;;
-    *)
-      echo "Sorry $OS_TYPE isn't supported yet. Patches welcome. :)"
-      exit 1
-  esac
+  if [[ "$OSTYPE" =~ darwin(.*) ]]
+  then
+    VERSION=${BASH_REMATCH[1]}
+    # Patch the R14 source in OS X 10.8 or newer (Mountain Lion, Mavericks)
+    if [[ $VERSION -ge 12 ]]
+    then
+      case "$RELEASE" in
+        R14*)
+          CFLAGS="-DERTS_DO_INCL_GLB_INLINE_FUNC_DEF"
+          apply_r14_osx_patch
+      esac
+    fi
+
+    CFLAGS="$CFLAGS -O0" ./configure --disable-hipe --without-javac --enable-smp-support \
+                       --enable-threads --enable-kernel-poll \
+                       --enable-darwin-64bit --prefix="$INSTALL" 1>>"$TMP_PATH/erlbrew.log" 2>&1
+  else
+    echo "Sorry $OSTYPE isn't supported yet. Patches welcome. :)"
+    exit 1
+  fi
 
   echo "Building Erlang $RELEASE"
   make 1>>"$TMP_PATH/erlbrew.log" 2>&1
-
 }
 
 install() {
@@ -176,6 +185,54 @@ list() {
     echo "No Erlang environments installed"
     exit 1
   fi
+}
+
+apply_r14_osx_patch() {
+  patch -p0 <<END_OF_PATCH
+--- erts/emulator/beam/beam_bp.c.orig	2011-10-03 13:12:07.000000000 -0500
++++ erts/emulator/beam/beam_bp.c	2013-10-04 13:42:03.000000000 -0500
+@@ -496,7 +496,8 @@
+ }
+ 
+ /* bp_hash */
+-ERTS_INLINE Uint bp_sched2ix() {
++#ifndef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
++ERTS_GLB_INLINE Uint bp_sched2ix() {
+ #ifdef ERTS_SMP
+     ErtsSchedulerData *esdp;
+     esdp = erts_get_scheduler_data();
+@@ -505,6 +506,7 @@
+     return 0;
+ #endif
+ }
++#endif
+ static void bp_hash_init(bp_time_hash_t *hash, Uint n) {
+     Uint size = sizeof(bp_data_time_item_t)*n;
+     Uint i;
+--- erts/emulator/beam/beam_bp.h.orig	2011-10-03 13:12:07.000000000 -0500
++++ erts/emulator/beam/beam_bp.h	2013-10-04 13:42:08.000000000 -0500
+@@ -144,7 +144,19 @@
+ #define ErtsSmpBPUnlock(BDC)
+ #endif
+ 
+-ERTS_INLINE Uint bp_sched2ix(void);
++ERTS_GLB_INLINE Uint bp_sched2ix(void);
++
++#ifdef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
++ERTS_GLB_INLINE Uint bp_sched2ix() {
++#ifdef ERTS_SMP
++    ErtsSchedulerData *esdp;
++    esdp = erts_get_scheduler_data();
++    return esdp->no - 1;
++#else
++    return 0;
++#endif
++}
++#endif
+ 
+ #ifdef ERTS_SMP
+ #define bp_sched2ix_proc(p) ((p)->scheduler_data->no - 1)
+END_OF_PATCH
 }
 
 case "$CMD" in


### PR DESCRIPTION
Xcode compiler has changed to clang in OS X 10.8 and 10.9. This prevents Erlang R14 from being built from source due to a bug in the way the **inline** operator was assumed to work in the Erlang code. Both R15 and R16 have a slightly different code structure for inline functions that work with these newer compilers. 

This patch will determine the Darwin OS version [11 = 10.7 (Lion), 12 = 10.8 (Mountain Lion) 13 = 10.9 (Mavericks)] and apply a code patch to R14 and pass in a proper C definition for a successful build.

Tested using R14B04, OS X 10.7, OS X 10.8 and OS X 10.9.
